### PR TITLE
Fix duplicate import and update tests

### DIFF
--- a/examples/simple_trading_example.py
+++ b/examples/simple_trading_example.py
@@ -75,10 +75,13 @@ def run_simple_trading_example():
     # Initialize agents
     manager.initialize_agents()
     
-    # Fetch market data
+    # Fetch market or options data for the configured symbol
     logger.info("Fetching market data...")
-    market_data = manager.fetch_market_data(symbol=config["trading"]["symbol"], days=config["data_fetch"]["days"])
-    logger.info(f"Fetched {len(market_data)} market data records")
+    manager.fetch_data_for_symbol(
+        symbol=config["trading"]["symbol"],
+        days=config["data_fetch"]["days"],
+    )
+    logger.info("Market data fetch completed")
     
     # Analyze sentiment
     logger.info("Analyzing sentiment...")

--- a/scripts/strategy/strategy.py
+++ b/scripts/strategy/strategy.py
@@ -20,7 +20,6 @@ from agent_interfaces import TradingSignal, VolatilitySmirkResult
 
 # Import utility functions
 from utils import get_data_directory, get_db_connection, setup_logger
-import os
 
 # Use relative paths with utility functions
 INDICATORS_DATA_PATH = os.path.join(get_data_directory(), "crude_oil_with_indicators.csv")

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -34,8 +34,9 @@ class TestRetryDecorators(unittest.TestCase):
         def test_func():
             return mock_func()
         
-        with self.assertRaises(RetryError):
+        with self.assertRaises(RetryError) as cm:
             test_func()
+        self.assertIsInstance(cm.exception.last_exception, ValueError)
         self.assertEqual(mock_func.call_count, 3)
 
     def test_retry_with_result_success(self):


### PR DESCRIPTION
## Summary
- remove duplicated `import os` in strategy
- update example to use `fetch_data_for_symbol`
- test `RetryError.last_exception` to ensure proper error captured

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683ff4643650832eb0f53bd3a7f7c105